### PR TITLE
Update tokenizer version in requirements.txt 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ six==1.16.0
 tensorboard==2.14.0
 test-tube==0.7.5
 timm==0.9.16
-tokenizers==0.10.3
+tokenizers==0.13.3
 torch==1.13.1+cu117
 torchaudio==0.13.1+cu117
 torchdiffeq==0.2.3


### PR DESCRIPTION
As mentioned in #14 , I also encountered the same version problem.

Since transformers 4.32.0 depends on tokenizers<0.14 and >=0.11.1, the original 0.10.3 version is not suitable.

I do the experiment with python 3.9.13.

I didn't find a website to show the depending relationships between the versions of transformers and tokenizers.

Maybe it is an alternative without specifying the version of tokenizer if we have specified the version of transformers 
