### PR TITLE
Support for less VRAM heavy alternative attentions (ReBased and Ring attention)

### DIFF
--- a/opensora/models/diffusion/latte/latte.py
+++ b/opensora/models/diffusion/latte/latte.py
@@ -27,6 +27,12 @@ try:
 except:
     XFORMERS_IS_AVAILBLE = False
 
+try:
+    # needs to have https://github.com/corl-team/rebased/ installed
+    from fla.ops.triton.rebased_fast import parallel_rebased
+except:
+    REBASED_IS_AVAILABLE = False
+    
 # from timm.models.layers.helpers import to_2tuple
 # from timm.models.layers.trace_utils import _assert
 
@@ -38,7 +44,7 @@ def modulate(x, shift, scale):
 #################################################################################
 
 class Attention(nn.Module):
-    def __init__(self, dim, num_heads=8, qkv_bias=False, attn_drop=0., proj_drop=0., use_lora=False, attention_mode='math'):
+    def __init__(self, dim, num_heads=8, qkv_bias=False, attn_drop=0., proj_drop=0., use_lora=False, attention_mode='math', eps=1e-12):
         super().__init__()
         assert dim % num_heads == 0, 'dim should be divisible by num_heads'
         self.num_heads = num_heads
@@ -49,6 +55,7 @@ class Attention(nn.Module):
         self.attn_drop = nn.Dropout(attn_drop)
         self.proj = nn.Linear(dim, dim)
         self.proj_drop = nn.Dropout(proj_drop)
+        self.eps = eps
 
     def forward(self, x):
         B, N, C = x.shape
@@ -69,6 +76,9 @@ class Attention(nn.Module):
             attn = attn.softmax(dim=-1)
             attn = self.attn_drop(attn)
             x = (attn @ v).transpose(1, 2).reshape(B, N, C)
+
+        elif self.attention_mode == 'rebased':
+            x = parallel_rebased(q, k, v, self.eps, True, True).reshape(B, N, C)
 
         else:
             raise NotImplemented


### PR DESCRIPTION
ReBased is an approximate Linear attention with learnable kernel (opposed to the usual quadratic costs of attention) https://github.com/corl-team/rebased/

Ring Attention is an another attention modification, enabling efficient paralellization. An implementation by lucidrains is here https://github.com/lucidrains/ring-attention-pytorch

These attentions can scale LLMs context to millions of tokens with the same vram usage, and it may be handy in text2video Transformers as well