### PR TITLE
[fix]: disable gradient computation to save GPU memory when reconstructing a video

### DIFF
--- a/opensora/models/ae/videobase/vqvae/videogpt/rec_video.py
+++ b/opensora/models/ae/videobase/vqvae/videogpt/rec_video.py
@@ -89,8 +89,9 @@ def main(args):
     x_vae = preprocess(read_video(video_path, num_frames, sample_rate), resolution, crop_size)
     x_vae = x_vae.to(device)
 
-    encodings, embeddings = vqvae.encode(x_vae, include_embeddings=True)
-    video_recon = vqvae.decode(encodings)
+    with torch.no_grad():
+        encodings, embeddings = vqvae.encode(x_vae, include_embeddings=True)
+        video_recon = vqvae.decode(encodings)
 
     # custom_to_video(x_vae[0], fps=sample_fps/sample_rate, output_file='origin_input.mp4')
     custom_to_video(video_recon[0], fps=sample_fps/sample_rate, output_file=args.rec_path)


### PR DESCRIPTION
same with https://github.com/PKU-YuanGroup/Open-Sora-Plan/pull/69. I find it is overwritten by https://github.com/PKU-YuanGroup/Open-Sora-Plan/commit/d5c61d5c0673580ab985d936d146e31a1044ad1c#diff-9411b31a5234a47ff6b98e1dc99c1b8fba53a46bf74dcbff53f80738a2556dc0