### PR TITLE
Fix einops bug: module 'keras.backend' has no attribute 'is_tensor'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
     "torch==2.1.2", "torchvision==0.16.2",
-    "transformers==4.32.0", "albumentations==1.4.0", "av==11.0.0", "decord==0.6.0", "einops==0.3.0", "fastapi==0.110.0",
+    "transformers==4.32.0", "albumentations==1.4.0", "av==11.0.0", "decord==0.6.0", "einops==0.7.0", "fastapi==0.110.0",
     "accelerate==0.21.0", "gdown==5.1.0", "h5py==3.10.0", "idna==3.6", 'imageio==2.34.0', "matplotlib==3.7.5", "numpy==1.24.4",
     "omegaconf==2.1.1", "opencv-python==4.9.0.80", "opencv-python-headless==4.9.0.80", "pandas==2.0.3", "pillow==10.2.0",
     "pydub==0.25.1", "pytorch-lightning==1.4.2", "pytorchvideo==0.1.5", "PyYAML==6.0.1", "regex==2023.12.25",


### PR DESCRIPTION
When I use scripts/sky/train.sh, codebase report einops bug:
![Dingtalk_20240309181855](https://github.com/PKU-YuanGroup/Open-Sora-Plan/assets/58427300/4236f82d-43d5-472e-891a-cd15aec5432d)
Finding solution from [this](https://github.com/williamyang1991/Rerender_A_Video/issues/26)
This bug may caused by the version of einops.