### PR TITLE
[feat]: use accelerate on multi-node

### DIFF
--- a/scripts/accelerate_configs/hostfile
+++ b/scripts/accelerate_configs/hostfile
@@ -1,0 +1,2 @@
+server1 slots=8  # your server name  and  GPU in total
+server2 slots=8

--- a/scripts/accelerate_configs/multi_node_example.yaml
+++ b/scripts/accelerate_configs/multi_node_example.yaml
@@ -1,0 +1,18 @@
+compute_environment: LOCAL_MACHINE
+distributed_type: DEEPSPEED
+deepspeed_config:
+ deepspeed_config_file: scripts/accelerate_configs/zero3_offload.json
+ deepspeed_hostfile: # FullPath here
+fsdp_config: {}
+machine_rank: 0
+main_process_ip: # main process ip
+main_process_port: 29501
+main_training_function: main
+num_machines: 2
+num_processes: 16
+rdzv_backend: static
+same_network: true
+tpu_env: []
+tpu_use_cluster: false
+tpu_use_sudo: false
+use_cpu: false


### PR DESCRIPTION
test on 2node each with 8 x 3090, communicating with ethernet.
to use this script, you should keep the conda environment paths and code paths consistent across all nodes, hence the use of a shared file system is recommended.
to communicate with IB, you need to export environment variables related to NCCL in script.