### PR TITLE
Correcting the issue of cache dir assignment in t5. py not taking advantage of dir or name

### DIFF
--- a/opensora/models/text_encoder/t5.py
+++ b/opensora/models/text_encoder/t5.py
@@ -27,7 +27,7 @@ class T5Embedder:
         self.hf_token = hf_token
         self.cache_dir = cache_dir
         self.dir_or_name = dir_or_name
-        cache_dir = os.path.join(self.cache_dir, 't5-v1_1-xxl')
+        cache_dir = os.path.join(self.cache_dir, self.dir_or_name)
         for filename in ['config.json', 'special_tokens_map.json', 'spiece.model', 'tokenizer_config.json',
                          'pytorch_model-00001-of-00002.bin', 'pytorch_model-00002-of-00002.bin', 'pytorch_model.bin.index.json']:
             hf_hub_download(repo_id='DeepFloyd/t5-v1_1-xxl', filename=filename, cache_dir=cache_dir,


### PR DESCRIPTION
The problem of cache dir assignment not utilizing dir or name

Correcting the issue of cache dir assignment in t5. py not taking advantage of dir or name

Original:

Cache dir=os. path. coin (self. cache dir, 't5 v1_1 xxl')

Update to:

Cache dir=os. path. coin (self. cache dir, self. dir or name)

