### PR TITLE
:recycle: [Refactor] path handling for clarity using os.path.dirname

### DIFF
--- a/opensora/utils/taming_download.py
+++ b/opensora/utils/taming_download.py
@@ -18,7 +18,7 @@ MD5_MAP = {
 
 
 def download(url, local_path, chunk_size=1024):
-    os.makedirs(os.path.split(local_path)[0], exist_ok=True)
+    os.makedirs(os.path.dirname(local_path), exist_ok=True)
     with requests.get(url, stream=True) as r:
         total_size = int(r.headers.get("content-length", 0))
         with tqdm(total=total_size, unit="B", unit_scale=True) as pbar:


### PR DESCRIPTION
Better way for handling path.

`os.path.split(local_path)[0]` -> `os.path.dirname(local_path)`