### PR TITLE
Update gradio_web_server.py

### DIFF
--- a/opensora/serve/gradio_web_server.py
+++ b/opensora/serve/gradio_web_server.py
@@ -7,6 +7,7 @@ import random
 
 import imageio
 import torch
+import torch_npu
 from diffusers import PNDMScheduler
 from huggingface_hub import hf_hub_download
 from torchvision.utils import save_image
@@ -27,6 +28,7 @@ from opensora.serve.gradio_utils import block_css, title_markdown, randomize_see
 
 @torch.inference_mode()
 def generate_img(prompt, sample_steps, scale, seed=0, randomize_seed=False, force_images=False):
+    torch_npu.npu.set_device(0)
     seed = int(randomize_seed_fn(seed, randomize_seed))
     set_env(seed)
     video_length = transformer_model.config.video_length if not force_images else 1


### PR DESCRIPTION
错误情况：
       开启webui开启后调用推理出现context丢失（为空）的问题
修复方案：
       思路：
              让restful接口可以获取到驱动的context
       修改：
              第10行增加了torch_npu的导入
              第31行增加torch_npu.npu.set_device(0)