### PR TITLE
[fix]: Fix variable naming errors

### DIFF
--- a/opensora/models/ae/imagebase/vqvae/quantize.py
+++ b/opensora/models/ae/imagebase/vqvae/quantize.py
@@ -365,8 +365,8 @@ class EMAVectorQuantizer(nn.Module):
     def __init__(self, n_embed, embedding_dim, beta, decay=0.99, eps=1e-5,
                  remap=None, unknown_index="random"):
         super().__init__()
-        self.codebook_dim = codebook_dim
-        self.num_tokens = num_tokens
+        self.codebook_dim = embedding_dim
+        self.num_tokens = n_embed
         self.beta = beta
         self.embedding = EmbeddingEMA(self.num_tokens, self.codebook_dim, decay, eps)
 


### PR DESCRIPTION
## Fix variable naming errors
`codebook_dim` -> `embedding_dim`
`num_tokens` -> `n_embed`