### PR TITLE
修复了一些语法错误，使得语句更通顺连贯。

### DIFF
--- a/docs/Data.md
+++ b/docs/Data.md
@@ -7,13 +7,13 @@
 
 We open source v1.0.0 all the training data, the annotations and the original video can be found [here](https://huggingface.co/datasets/LanguageBind/Open-Sora-Plan-v1.0.0).
 
-These data consist of segmented video clips, with each clip obtained through center cropping. The resolution of each clip is 512×512. There are 64 frames in each clip, and their corresponding captions can be found in the annotation files.
+The data consists of segmented video clips, with each clip obtained through center cropping. The resolution of each clip is 512×512. There are 64 frames in each clip, and their corresponding captions can be found in the annotation files.
 
 We present additional details in [report](https://github.com/PKU-YuanGroup/Open-Sora-Plan/blob/main/docs/Report-v1.0.0.md#data-construction) and [Open-Sora-Dataset](https://github.com/PKU-YuanGroup/Open-Sora-Dataset).
 
-### Class-condition
+### Class-conditioned
 
-In order to download UCF-101 dataset, you can download the necessary files in [here](https://www.crcv.ucf.edu/data/UCF101.php). The code assumes a `ucf101` directory with the following structure
+In order to generate UCF-101 dataset, you can download the necessary files from [here](https://www.crcv.ucf.edu/data/UCF101.php). The code assumes a `ucf101` directory with the following structure
 ```
 UCF-101/
     ApplyEyeMakeup/
@@ -25,9 +25,9 @@ UCF-101/
         ...
 ```
 
-### Un-condition
+### Un-conditioned
 
-We use [sky_timelapse](https://drive.google.com/open?id=1xWLiU-MBGN7MrsFHQm4_yXmfHBsMbJQo), which is an un-condition datasets.
+We use [sky_timelapse](https://drive.google.com/open?id=1xWLiU-MBGN7MrsFHQm4_yXmfHBsMbJQo), which is an un-conditioned dataset.
 
 ```
 sky_timelapse


### PR DESCRIPTION
修改部分： 
1. data不可数且单复数同型，不可以用these。
2. 在同一句重复使用download使得语句不流畅，修改为generate + download提高可读性。
3. download from here比in here更合适。
4. un-conditioned, class-conditioned作形容词形容数据集。单独用一个名词不是很合适。