### PR TITLE
[fix]: Fix wrong file name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ python -m opensora.serve.gradio_web_server --version 221x512x512
 #### CLI Inference
 
 ```bash
-sh scripts/text_condition/sample_video.sh
+sh scripts/text_condition/sample_image.sh
 ```
 
 ### Datasets


### PR DESCRIPTION
What does this PR do? 
---- 
This PR updates the readme file by correcting a command line interface example, replacing the non-existent script file sample_video.sh with the existing script file sample_image.sh.