### PR TITLE
[fix] fix the path typo for google/mt5-xxl in gradio_web_server.py

### DIFF
--- a/opensora/serve/gradio_web_server.py
+++ b/opensora/serve/gradio_web_server.py
@@ -80,9 +80,9 @@ if torch.cuda.is_available():
     # text_encoder = MT5EncoderModel.from_pretrained(args.text_encoder_name, cache_dir=args.cache_dir, 
     #                                                low_cpu_mem_usage=True, torch_dtype=weight_dtype)
     # tokenizer = AutoTokenizer.from_pretrained(args.text_encoder_name, cache_dir=args.cache_dir)
-    text_encoder = MT5EncoderModel.from_pretrained("/storage/ongoing/new/Open-Sora-Plan/cache_dir/mt5-xxl", cache_dir=args.cache_dir, 
+    text_encoder = MT5EncoderModel.from_pretrained("google/mt5-xxl", cache_dir=args.cache_dir, 
                                                    low_cpu_mem_usage=True, torch_dtype=weight_dtype)
-    tokenizer = AutoTokenizer.from_pretrained("/storage/ongoing/new/Open-Sora-Plan/cache_dir/mt5-xxl", cache_dir=args.cache_dir)
+    tokenizer = AutoTokenizer.from_pretrained("google/mt5-xxl", cache_dir=args.cache_dir)
     transformer = OpenSoraT2V.from_pretrained(args.model_path, cache_dir=args.cache_dir, low_cpu_mem_usage=False, 
                                               device_map=None, torch_dtype=weight_dtype)
     scheduler = EulerAncestralDiscreteScheduler()

--- a/scripts/text_condition/gpu/sample_t2v.sh
+++ b/scripts/text_condition/gpu/sample_t2v.sh
@@ -3,7 +3,7 @@ CUDA_VISIBLE_DEVICES=7 python opensora/sample/sample_t2v.py \
     --num_frames 29 \
     --height 480 \
     --width 640 \
-    --cache_dir "../cache_dir" \
+    --cache_dir "./cache_dir" \
     --text_encoder_name google/mt5-xxl \
     --text_prompt examples/prompt_list_0.txt \
     --ae CausalVAEModel_D4_4x8x8 \

--- a/scripts/text_condition/gpu/sample_t2v_ddp.sh
+++ b/scripts/text_condition/gpu/sample_t2v_ddp.sh
@@ -5,7 +5,7 @@ torchrun --nnodes=1 --nproc_per_node 8  --master_port 29503 \
     --num_frames 93 \
     --height 720 \
     --width 1280 \
-    --cache_dir "../cache_dir" \
+    --cache_dir "./cache_dir" \
     --text_encoder_name google/mt5-xxl \
     --text_prompt examples/prompt_list_0.txt \
     --ae CausalVAEModel_D4_4x8x8 \

--- a/scripts/text_condition/gpu/sample_t2v_sp.sh
+++ b/scripts/text_condition/gpu/sample_t2v_sp.sh
@@ -5,7 +5,7 @@ torchrun --nnodes=1 --nproc_per_node 8  --master_port 29503 \
     --num_frames 93 \
     --height 720 \
     --width 1280 \
-    --cache_dir "../cache_dir" \
+    --cache_dir "./cache_dir" \
     --text_encoder_name google/mt5-xxl \
     --text_prompt examples/prompt_list_0.txt \
     --ae CausalVAEModel_D4_4x8x8 \


### PR DESCRIPTION
1. The original path of mt5-xxl in `gradio_web_server.py` is wrong `/storage/ongoing/new/Open-Sora-Plan/cache_dir/mt5-xxl`. Fix it as `google/mt5-xxl`
2. the cache_path of `google/mt5-xxl` is inconsistent in `gradio_web_server.py` and `sample_t2v.sh`, which will lead the user to download the model twice.