### PR TITLE
[fix] fix the typo in scripts/text_condition/gpu/sample_inpaint.sh

### DIFF
--- a/scripts/text_condition/gpu/sample_inpaint.sh
+++ b/scripts/text_condition/gpu/sample_inpaint.sh
@@ -15,4 +15,4 @@ CUDA_VISIBLE_DEVICES=7 python -m opensora.sample.sample_inpaint \
     --num_sampling_steps 100 \
     --enable_tiling \
     --max_sequence_length 512 \
-    --sample_method PDNM \
+    --sample_method PNDM \


### PR DESCRIPTION
* [fix] fix the typo in scripts/text_condition/gpu/sample_inpaint.sh : "PDNM" to "PNDM"