### PR TITLE
fix: correct attention mask padding amount in prepare_attention_mask

### DIFF
--- a/opensora/models/diffusion/opensora_v1_3/modules.py
+++ b/opensora/models/diffusion/opensora_v1_3/modules.py
@@ -114,7 +114,7 @@ class Attention(Attention_):
         current_length: int = attention_mask.shape[-1]
         if current_length != target_length:
             print(f'attention_mask.shape, {attention_mask.shape}, current_length, {current_length}, target_length, {target_length}')
-            attention_mask = F.pad(attention_mask, (0, target_length), value=0.0)
+            attention_mask = F.pad(attention_mask, (0, target_length - current_length), value=0.0)
 
         if out_dim == 3:
             if attention_mask.shape[0] < batch_size * head_size:


### PR DESCRIPTION
## Summary

Fix incorrect `F.pad` call in `Attention.prepare_attention_mask()` (`opensora/models/diffusion/opensora_v1_3/modules.py`).

`F.pad(tensor, (0, N))` pads **by** `N` elements on the right — it does not pad **to** a total length of `N`. The existing code uses `(0, target_length)`, which produces a tensor of length `current_length + target_length` instead of `target_length`.

### Before
```python
attention_mask = F.pad(attention_mask, (0, target_length), value=0.0)
```

### After
```python
attention_mask = F.pad(attention_mask, (0, target_length - current_length), value=0.0)
```

This ensures the mask is padded to exactly `target_length` elements, as intended.